### PR TITLE
Reflect latest Native File System API changes

### DIFF
--- a/comps/ChooseDirectory.js
+++ b/comps/ChooseDirectory.js
@@ -16,7 +16,7 @@ import {useState, useCallback} from 'react';
 
 async function promptUserForDirectory(setDirectory) {
   try {
-    const handle = await window.chooseFileSystemEntries({type: 'openDirectory'});
+    const handle = await window.chooseFileSystemEntries({type: 'open-directory'});
     setDirectory(handle);
   } catch (e) {
     console.log(`ERROR: ${JSON.stringify(e.message)}`);


### PR DESCRIPTION
The various `type`s are now dash-separated keywords.